### PR TITLE
Feature: sets with expiring items

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const uncorded = require('uncorded');
 const server = uncorded.createServer({
   discovery: uncorded.discovery.elb({
     region: 'us-east-1',
-    elbName: 'uncorded-test-elb'
+    elbName: 'uncorded-elb'
   })
 });
 const tokens = server.createSet('tokens');

--- a/lib/expiring-set.js
+++ b/lib/expiring-set.js
@@ -41,15 +41,15 @@ class ExpiringSet {
   }
 
   get(id) {
-    if (this.removals[id]) {
-      return undefined;
-    }
-
     const meta = this.adds[id];
     if (meta) {
       const delta = Date.now() - meta.ts;
       if (delta >= this.ttl) {
         delete this.adds[id];
+        delete this.removals[id];
+        return undefined;
+      }
+      if (this.removals[id]) {
         return undefined;
       }
       return meta;
@@ -85,6 +85,7 @@ class ExpiringSet {
     const now = Date.now();
     while (this.head && now >= this.head.ts) {
       delete this.adds[this.head.id];
+      delete this.removals[this.head.id];
       this.head = this.head.next;
     }
     if (!this.head) {

--- a/lib/expiring-set.js
+++ b/lib/expiring-set.js
@@ -57,7 +57,15 @@ class ExpiringSet {
   }
 
   merge(state) {
-    Object.assign(this.adds, state.adds);
+    // consider switching to lazily evaluated collection library
+    for (let id in state.adds) {
+      if (this.adds[id]) { continue; }
+      const addition = state.adds[id];
+      this.adds[id] = addition;
+      this.sortedInsert({
+        id, ts: addition.ts + this.ttl
+      });
+    }
     Object.assign(this.removals, state.removals);
   }
 
@@ -81,6 +89,26 @@ class ExpiringSet {
     }
     if (!this.head) {
       this.tail = null;
+    }
+  }
+
+  sortedInsert(item) {
+    if (!this.head) {
+      this.head = item;
+      return;
+    }
+
+    let current = this.head;
+    let previous = {};
+    while (current) {
+      const newItemIsOlder = item.ts < current.ts;
+      if (newItemIsOlder) {
+        item.next = current;
+        previous.next = item;
+        break;
+      }
+      previous = current;
+      current = current.next;
     }
   }
 }

--- a/lib/expiring-set.js
+++ b/lib/expiring-set.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const clone = require('lodash/cloneDeep');
+const uuid = require('uuid');
+
+/*
+ * Items are checked for expiry when retrieved. Garbage collection of expired items is
+ * achieved using a singly-linked list. The HEAD of the linked list points to the eldest
+ * item in the set, so garbage collection takes O(n) where n > 0 represents the number
+ * of expired items. GC for no expired items is a O(1) operation.
+ */
+class ExpiringSet {
+  constructor(options) {
+    this.ttl = options.ttl;
+    this.adds = {};
+    this.removals = {};
+    this.head = null;
+    this.tail = null;
+  }
+
+  add(doc) {
+    const meta = { id: uuid.v4(), ts: Date.now(), doc: clone(doc) };
+    this.adds[meta.id] = meta;
+
+    const current = {
+      id: meta.id,
+      ts: Date.now() + this.ttl,
+      next: null
+    };
+    if (this.tail) {
+      // add entry to end of list
+      this.tail.next = current;
+      this.tail = current;
+    } else {
+      // initialize list
+      this.head = current;
+      this.tail = current;
+    }
+
+    return meta;
+  }
+
+  get(id) {
+    if (this.removals[id]) {
+      return undefined;
+    }
+
+    const meta = this.adds[id];
+    if (meta) {
+      const delta = Date.now() - meta.ts;
+      if (delta >= this.ttl) {
+        delete this.adds[id];
+        return undefined;
+      }
+      return meta;
+    }
+  }
+
+  merge(state) {
+    Object.assign(this.adds, state.adds);
+    Object.assign(this.removals, state.removals);
+  }
+
+  remove(id) {
+    const meta = this.get(id);
+    if (meta) {
+      this.removals[id] = id;
+    }
+    return meta;
+  }
+
+  state() {
+    return { adds: this.adds, removals: this.removals };
+  }
+
+  gc() {
+    const now = Date.now();
+    while (this.head && now >= this.head.ts) {
+      delete this.adds[this.head.id];
+      this.head = this.head.next;
+    }
+    if (!this.head) {
+      this.tail = null;
+    }
+  }
+}
+
+module.exports = ExpiringSet;

--- a/lib/set-stream.js
+++ b/lib/set-stream.js
@@ -38,7 +38,7 @@ class SetStream extends Duplex {
   }
 
   state() {
-    return { adds: this._set.adds, removals: this._set.removals };
+    return this._set.state();
   }
 
   _read() {}

--- a/lib/set.js
+++ b/lib/set.js
@@ -34,6 +34,10 @@ class Set {
     }
     return meta;
   }
+
+  state() {
+    return { adds: this.adds, removals: this.removals };
+  }
 }
 
 module.exports = Set;

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,14 +18,14 @@ resource "aws_elb" "elb" {
   listener {
     lb_port = 80
     lb_protocol = "http"
-    instance_port = 8080
+    instance_port = 8199
     instance_protocol = "http"
   }
 
   health_check {
     healthy_threshold = 2
     unhealthy_threshold = 5
-    target = "HTTP:8080/"
+    target = "HTTP:8199/"
     interval = 30
     timeout = 5
   }

--- a/test/expiring-set-test.js
+++ b/test/expiring-set-test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+const assert = require('chai').assert;
+const Set = require('../lib/expiring-set');
+
+let i = 0;
+const createSet = () => new Set({ ttl: 50 });
+const createDoc = () => {
+  return { data: i++ };
+};
+
+describe('expiring-set', () => {
+  it('can add item', () => {
+    const set = createSet();
+    const doc = createDoc();
+    const metadata = set.add(doc);
+    assert.equal(typeof(metadata.id), 'string');
+    assert.equal(metadata.id.length, 36);
+  });
+
+  describe('given an expired item', () => {
+    let doc, metadata, set;
+
+    beforeEach(done => {
+      set = new Set({ ttl: 50 });
+      doc = createDoc();
+      metadata = set.add(doc);
+      setTimeout(done, 51);
+    });
+
+    it('the item cannot be retrieved', () => {
+      const found = set.get(metadata.id);
+      assert.isUndefined(found);
+    });
+
+    it('the item is evicted from state after retrieval to reclaim memory', () => {
+      set.get(metadata.id);
+      const state = set.state();
+      assert.isUndefined(state.adds[metadata.id]);
+    });
+
+    it('the item is evicted from state by garbage collection', () => {
+      set.gc();
+      const state = set.state();
+      assert.isUndefined(state.adds[metadata.id]);
+    });
+
+    it.skip('the item is evicted from state automatically to reclaim memory', () => {
+      const state = set.state();
+      assert.isUndefined(state.adds[metadata.id]);
+    });
+
+    it('garbage collection continues working after expiring all items in set', (done) => {
+      const newdoc = set.add(createDoc());
+      setTimeout(() => {
+        set.gc();
+        const state = set.state();
+        assert.isUndefined(state.adds[newdoc.id]);
+        done();
+      }, 51);
+    });
+  });
+
+  describe('given an expired item and a non-expired item', () => {
+    let activeMetadata, expiredMetadata, set;
+    beforeEach((done) => {
+      set = new Set({ ttl: 50 });
+      const expired = createDoc();
+      expiredMetadata = set.add(expired);
+      setTimeout(() => {
+        const active = createDoc();
+        activeMetadata = set.add(active);
+        setTimeout(() => {
+          done();
+        }, 51 - 15);
+      }, 15);
+    });
+
+    it('non-expired item can still be retrieved', () => {
+      const found = set.get(activeMetadata.id);
+      assert.isDefined(found);
+    });
+
+    it('non-expired item is still in state', () => {
+      set.gc();
+      const state = set.state();
+      assert.isDefined(state.adds[activeMetadata.id]);
+    });
+
+    it('expired item cannot be retrieved', () => {
+      const found = set.get(expiredMetadata.id);
+      assert.isUndefined(found);
+    });
+
+    it('expired item is evicted from state after retrieval to reclaim memory', () => {
+      set.get(expiredMetadata.id);
+      const state = set.state();
+      assert.isUndefined(state.adds[expiredMetadata.id]);
+    });
+  });
+
+  it('generates unique id for each item', () => {
+    const set = createSet();
+    const first = set.add(createDoc());
+    const second = set.add(createDoc());
+    assert.notEqual(first.id, second.id);
+  });
+
+  it('can retrieve previously added item', () => {
+    const set = createSet();
+    const doc = createDoc();
+    const metadata = set.add(doc);
+    const found = set.get(metadata.id);
+    assert.deepEqual(found.doc, doc);
+    assert.notEqual(found, doc, 'persists a copy of original');
+  });
+
+  it('can remove an item', () => {
+    const set = createSet();
+    const doc = createDoc();
+    const metadata = set.add(doc);
+
+    const removed = set.remove(metadata.id);
+    assert.deepEqual(removed, metadata);
+    const found = set.get(metadata.id);
+    assert.isUndefined(found);
+  });
+
+  it('can merge adds', () => {
+    const a = createSet();
+    const adoc = createDoc();
+    const ameta = a.add(adoc);
+
+    const b = createSet();
+    const bdoc = createDoc();
+    const bmeta = b.add(bdoc);
+
+    a.merge(b.state());
+    assert.deepEqual(a.get(ameta.id).doc, adoc);
+    assert.deepEqual(a.get(bmeta.id).doc, bdoc);
+  });
+
+  it('can merge removals', () => {
+    const a = createSet();
+    const adoc = createDoc();
+    const ameta = a.add(adoc);
+
+    const b = createSet();
+    b.merge(a.state()); // capture addition so it can be removed
+    b.remove(ameta.id);
+
+    a.merge(b.state());
+    assert.isUndefined(a.get(ameta.id));
+  });
+
+  it('only tombstone removals for items already in set', () => {
+    const a = createSet();
+    const adoc = createDoc();
+    const ameta = a.add(adoc);
+
+    const b = createSet();
+    const removed = b.remove(ameta.id);
+
+    a.merge(b.state());
+
+    assert.isUndefined(removed);
+    assert.deepEqual(a.get(ameta.id), ameta);
+  });
+});

--- a/test/expiring-set-test.js
+++ b/test/expiring-set-test.js
@@ -19,47 +19,50 @@ describe('expiring-set', () => {
   });
 
   describe('given an expired item', () => {
-    let doc, metadata, set;
+    const test = {};
 
     beforeEach(done => {
-      set = new Set({ ttl: 50 });
-      doc = createDoc();
-      metadata = set.add(doc);
+      test.set = new Set({ ttl: 50 });
+      test.metadata = test.set.add(createDoc());
       setTimeout(done, 51);
     });
 
+    expiredItemTests(test);
+  });
+
+  function expiredItemTests(test) {
     it('the item cannot be retrieved', () => {
-      const found = set.get(metadata.id);
+      const found = test.set.get(test.metadata.id);
       assert.isUndefined(found);
     });
 
     it('the item is evicted from state after retrieval to reclaim memory', () => {
-      set.get(metadata.id);
-      const state = set.state();
-      assert.isUndefined(state.adds[metadata.id]);
+      test.set.get(test.metadata.id);
+      const state = test.set.state();
+      assert.isUndefined(state.adds[test.metadata.id]);
     });
 
     it('the item is evicted from state by garbage collection', () => {
-      set.gc();
-      const state = set.state();
-      assert.isUndefined(state.adds[metadata.id]);
+      test.set.gc();
+      const state = test.set.state();
+      assert.isUndefined(state.adds[test.metadata.id]);
     });
 
     it.skip('the item is evicted from state automatically to reclaim memory', () => {
-      const state = set.state();
-      assert.isUndefined(state.adds[metadata.id]);
+      const state = test.set.state();
+      assert.isUndefined(state.adds[test.metadata.id]);
     });
 
     it('garbage collection continues working after expiring all items in set', (done) => {
-      const newdoc = set.add(createDoc());
+      const newdoc = test.set.add(createDoc());
       setTimeout(() => {
-        set.gc();
-        const state = set.state();
+        test.set.gc();
+        const state = test.set.state();
         assert.isUndefined(state.adds[newdoc.id]);
         done();
       }, 51);
     });
-  });
+  }
 
   describe('given an expired item and a non-expired item', () => {
     let activeMetadata, expiredMetadata, set;

--- a/test/expiring-set-test.js
+++ b/test/expiring-set-test.js
@@ -30,6 +30,43 @@ describe('expiring-set', () => {
     expiredItemTests(test);
   });
 
+  describe('given an expired item received from a peer', () => {
+    const test = {};
+
+    beforeEach(done => {
+      const peer = new Set({ ttl: 50 });
+      test.metadata = peer.add(createDoc());
+
+      test.set = new Set({ ttl: 50 });
+      test.set.merge(peer);
+      setTimeout(done, 51);
+    });
+
+    expiredItemTests(test);
+  });
+
+  describe('given expired items and an expired item received from a peer', () => {
+    const test = {};
+
+    beforeEach(done => {
+      test.set = new Set({ ttl: 50 });
+      test.set.add(createDoc());
+
+      setTimeout(() => {
+        const peer = new Set({ ttl: 50 });
+        test.metadata = peer.add(createDoc());
+
+        setTimeout(() => {
+          test.set.add(createDoc());
+          test.set.merge(peer);
+          setTimeout(done, 51);
+        }, 1);
+      }, 1);
+    });
+
+    expiredItemTests(test);
+  });
+
   function expiredItemTests(test) {
     it('the item cannot be retrieved', () => {
       const found = test.set.get(test.metadata.id);

--- a/test/expiring-set-test.js
+++ b/test/expiring-set-test.js
@@ -67,6 +67,19 @@ describe('expiring-set', () => {
     expiredItemTests(test);
   });
 
+  describe('given a removed expired item', () => {
+    const test = {};
+
+    beforeEach(done => {
+      test.set = new Set({ ttl: 50 });
+      test.metadata = test.set.add(createDoc());
+      test.set.remove(test.metadata.id);
+      setTimeout(done, 51);
+    });
+
+    expiredItemTests(test);
+  });
+
   function expiredItemTests(test) {
     it('the item cannot be retrieved', () => {
       const found = test.set.get(test.metadata.id);
@@ -77,17 +90,20 @@ describe('expiring-set', () => {
       test.set.get(test.metadata.id);
       const state = test.set.state();
       assert.isUndefined(state.adds[test.metadata.id]);
+      assert.isUndefined(state.removals[test.metadata.id]);
     });
 
     it('the item is evicted from state by garbage collection', () => {
       test.set.gc();
       const state = test.set.state();
       assert.isUndefined(state.adds[test.metadata.id]);
+      assert.isUndefined(state.removals[test.metadata.id]);
     });
 
     it.skip('the item is evicted from state automatically to reclaim memory', () => {
       const state = test.set.state();
       assert.isUndefined(state.adds[test.metadata.id]);
+      assert.isUndefined(state.removals[test.metadata.id]);
     });
 
     it('garbage collection continues working after expiring all items in set', (done) => {

--- a/test/set-test.js
+++ b/test/set-test.js
@@ -53,7 +53,7 @@ describe('set', () => {
     const bdoc = createDoc();
     const bmeta = b.add(bdoc);
 
-    a.merge(b);
+    a.merge(b.state());
     assert.deepEqual(a.get(ameta.id).doc, adoc);
     assert.deepEqual(a.get(bmeta.id).doc, bdoc);
   });
@@ -64,10 +64,10 @@ describe('set', () => {
     const ameta = a.add(adoc);
 
     const b = new Set();
-    b.merge(a); // capture addition so it can be removed
+    b.merge(a.state()); // capture addition so it can be removed
     b.remove(ameta.id);
 
-    a.merge(b);
+    a.merge(b.state());
     assert.isUndefined(a.get(ameta.id));
   });
 
@@ -79,7 +79,7 @@ describe('set', () => {
     const b = new Set();
     const removed = b.remove(ameta.id);
 
-    a.merge(b);
+    a.merge(b.state());
 
     assert.isUndefined(removed);
     assert.deepEqual(a.get(ameta.id), ameta);


### PR DESCRIPTION
Initial implementation of an expiring set. Garbage Collection has been implemented but is not yet invoked automatically.

Items are checked for expiry when retrieved. Garbage collection of expired items is achieved using a singly-linked list. The HEAD of the linked list points to the eldest item in the set, so garbage collection takes O(n) where n > 0 represents the number of expired items. GC for no expired items is a O(1) operation.